### PR TITLE
chore: sync models.dev upstream

### DIFF
--- a/packages/web/src/render.tsx
+++ b/packages/web/src/render.tsx
@@ -340,7 +340,7 @@ export const Rendered = renderToString(
           )
           .flatMap(([providerId, provider]) =>
             Object.entries(provider.models)
-              .filter(([, model]) => !model.alpha && !model.beta)
+              .filter(([, model]) => !model.alpha)
               .sort(([, modelA], [, modelB]) =>
                 modelA.name.localeCompare(modelB.name)
               )

--- a/providers/chutes/models/deepseek-ai/DeepSeek-V3.2-Exp.toml
+++ b/providers/chutes/models/deepseek-ai/DeepSeek-V3.2-Exp.toml
@@ -1,0 +1,20 @@
+name = "DeepSeek V3.2 Exp"
+attachment = false         # or false - supports file attachments
+reasoning = true           # or true - supports reasoning / chain-of-thought
+tool_call = true            # or false - supports tool calling
+temperature = true          # Knowledge-cutoff date
+open_weights = true
+release_date = "2025-09-29" # First public release date
+last_updated = "2025-09-29" # Most recent update date
+
+[cost]
+input = 0.2500                # Cost per million input tokens (USD)
+output = 0.3500            # Cost per million output tokens (USD)
+
+[limit]
+context = 128_000           # Maximum context window (tokens)
+output = 64_000              # Maximum output tokens
+
+[modalities]
+input = ["text"]   # Supported input modalities
+output = ["text"]           # Supported output modalities

--- a/providers/chutes/models/zai-org/GLM-4.6-turbo.toml
+++ b/providers/chutes/models/zai-org/GLM-4.6-turbo.toml
@@ -1,0 +1,21 @@
+name = "GLM 4.6 Turbo"
+release_date = "2025-10-03"
+last_updated = "2025-10-03"
+attachment = false
+reasoning = true
+temperature = true
+tool_call = true
+knowledge = "2025-04"
+open_weights = true
+
+[cost]
+input = 1.15
+output = 3.25
+
+[limit]
+context = 204800
+output = 131072
+
+[modalities]
+input = ["text"]
+output = ["text"]


### PR DESCRIPTION
Automated subtree sync from upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new model options: DeepSeek V3.2 (Experimental) and GLM‑4.6 Turbo, with metadata, capabilities, pricing, token limits, and text modalities.
* **Behavior Changes**
  * Model listing now includes beta models (previously excluded), while alpha models remain hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->